### PR TITLE
Add scope provided to bukkit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
             <artifactId>craftbukkit</artifactId>
             <version>1.13</version>
             <type>jar</type>
+            <scope>provided</scope>
         </dependency>
         <!--Vault API-->
         <dependency>


### PR DESCRIPTION
Added scope provided to bukkit dependency so server jar isn't included with plugin.