### PR TITLE
Properly relocate dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,14 @@
                                     <pattern>com.songoda.core</pattern>
                                     <shadedPattern>${project.groupId}.ultimatekits.core</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>${project.groupId}.ultimatekits.org.slf4j</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.zaxxer.hikari</pattern>
+                                    <shadedPattern>${project.groupId}.ultimatekits.com.zaxxer.hikari</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Shaded dependencies need to be relocated so that they do not conflict with other plugins' dependencies