### PR TITLE
Fixed interactions with kit blocks

### DIFF
--- a/src/main/resources/en_US.lang
+++ b/src/main/resources/en_US.lang
@@ -187,6 +187,7 @@ event:
     wrongkey: '&cThis key doesn''t belong to this kit..'
     success: '&9Successfully opened a crate.'
     given: '&9You have received a %crate% %kit% crate.'
+    needkey: '&cYou need the right key to get this kit'
   claim:
     cannotafford: '&9You cannot afford to buy kit &7%kit%&9.'
     nottwice: '&9You can only receive this kit once.'


### PR DESCRIPTION
I found bug, which this time can be used by players to advantage.
After setting the `/kitadmin set better_tools` block and selecting `Kit type` to `Crate` in the settings, a player can get a kit without a key (by hand or any block). Interestingly, when a player tries to open a chest with a key to another kit (for example, `/kitadmin key brianna Insane player`) - he will not get a set and will get a message in chat.

On the other hand, `Kit type` set to `Preview` allows to receive the kit with the corresponding key, and the right mouse button to preview - this is how the `Crate` setting should behave.
The `Preview` should be a preview regardless of whether the player has a key for that kit.


I fixed this bug in the following way:

1. When the player right-clicks on the kit block, a preview of the kit will be displayed every time (except shift + right, then editing if the player has permissions).
2. When you click the left mouse button, an action will occur depending on the type of kit: `Preview` - preview, `Crate` - player holding the correct key in his hand will receive a kit, otherwise he will receive a message about the need for a key or an invalid key, `Claim` - player will receive or buy a kit.

By the way, I fixed the bug related to listening only to `TRIPWIRE_HOOK`, instead of the key material set by the administrator in the config.


Great request, check if I wrote everything correctly - I am not a java developer.